### PR TITLE
Update Readme for migrate db

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ These steps are designed to get you rolling quickly, but more complete install/s
 
 4. Migrate db::
 
-    fabric-bolt migrate
+    fabric-bolt syncdb --migrate
 
 5. Create admin user, then follow the prompts to create an email and password::
 


### PR DESCRIPTION
You will get error : "django.db.utils.OperationalError: no such table: south_migrationhistory" if using migrate