### PR TITLE
Add shell setting, make virtualenv setup work when running on uWSGI

### DIFF
--- a/fabric_bolt/projects/sockets.py
+++ b/fabric_bolt/projects/sockets.py
@@ -6,6 +6,8 @@ import time
 import fcntl
 import os
 
+from django.conf import settings
+
 from socketio.namespace import BaseNamespace
 from socketio.mixins import RoomsMixin, BroadcastMixin
 from socketio.sdjango import namespace
@@ -51,7 +53,8 @@ class ChatNamespace(BaseNamespace, RoomsMixin, BroadcastMixin):
             build_command(self.deployment, self.request.session, False),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE
+            stdin=subprocess.PIPE,
+            executable=getattr(settings, 'SHELL', '/bin/sh'),
         )
 
         fd = self.process.stdout.fileno()

--- a/fabric_bolt/projects/util.py
+++ b/fabric_bolt/projects/util.py
@@ -4,7 +4,6 @@ import subprocess
 
 from django.utils.text import slugify
 from django.conf import settings
-from django.contrib import messages
 from django.core.cache import cache
 
 from virtualenv import create_environment

--- a/fabric_bolt/projects/util.py
+++ b/fabric_bolt/projects/util.py
@@ -6,8 +6,6 @@ from django.utils.text import slugify
 from django.conf import settings
 from django.core.cache import cache
 
-from virtualenv import create_environment
-
 # These options are passed to Fabric as: fab task --abort-on-prompts=True --user=root ...
 fabric_special_options = ['no_agent', 'forward-agent', 'config', 'disable-known-hosts', 'keepalive',
                           'password', 'parallel', 'no-pty', 'reject-unknown-hosts', 'skip-bad-hosts', 'timeout',
@@ -41,7 +39,7 @@ def setup_virtual_env_if_needed(repo_dir):
     env_dir = os.path.join(repo_dir, 'env')
     if not os.path.exists(env_dir):
         os.makedirs(env_dir)
-        create_environment(env_dir)
+        check_output("virtualenv {}".format(env_dir))
 
 
 def update_project_requirements(project, repo_dir, activate_loc):

--- a/fabric_bolt/projects/util.py
+++ b/fabric_bolt/projects/util.py
@@ -40,7 +40,7 @@ def setup_virtual_env_if_needed(repo_dir):
     env_dir = os.path.join(repo_dir, 'env')
     if not os.path.exists(env_dir):
         os.makedirs(env_dir)
-        check_output("virtualenv {}".format(env_dir))
+        check_output("virtualenv {}".format(env_dir), shell=True)
 
 
 def update_project_requirements(project, repo_dir, activate_loc):

--- a/fabric_bolt/projects/util.py
+++ b/fabric_bolt/projects/util.py
@@ -15,15 +15,15 @@ fabric_special_options = ['no_agent', 'forward-agent', 'config', 'disable-known-
                           'command-timeout', 'user', 'warn-only', 'pool-size']
 
 
+def check_output(command):
+    return subprocess.check_output(command, shell=True, executable=getattr(settings, 'SHELL', '/bin/sh'))
+
+
 def check_output_with_ssh_key(command):
     if getattr(settings, 'GIT_SSH_KEY_LOCATION', None):
-        return subprocess.check_output(
-            'ssh-agent bash -c "ssh-add {};{}"'.format(settings.GIT_SSH_KEY_LOCATION, command),
-            shell=True
-        )
+        return check_output('ssh-agent bash -c "ssh-add {};{}"'.format(settings.GIT_SSH_KEY_LOCATION, command))
     else:
-        out = subprocess.check_output([command], shell=True)
-        return out
+        return check_output(command)
 
 
 def update_project_git(project, cache_dir, repo_dir):

--- a/fabric_bolt/projects/util.py
+++ b/fabric_bolt/projects/util.py
@@ -13,7 +13,10 @@ fabric_special_options = ['no_agent', 'forward-agent', 'config', 'disable-known-
 
 
 def check_output(command, shell=False):
-    return subprocess.check_output(command, shell=shell, executable=getattr(settings, 'SHELL', '/bin/sh'))
+    executable = None
+    if shell:
+        executable = getattr(settings, 'SHELL', '/bin/sh')
+    return subprocess.check_output(command, shell=shell, executable=executable)
 
 
 def check_output_with_ssh_key(command):

--- a/fabric_bolt/projects/views.py
+++ b/fabric_bolt/projects/views.py
@@ -446,7 +446,8 @@ class DeploymentOutputStream(View):
                 build_command(self.object, self.request.session),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                shell=True
+                shell=True,
+                executable=getattr(settings, 'SHELL', '/bin/sh'),
             )
 
             all_output = ''


### PR DESCRIPTION
This fixed some issues I've found in my environment, the first one the default shell not being able to run "source" and the second one, virtualenv not being created because sys.executable was not the python binary but the uWSGI one.

 